### PR TITLE
silent errors

### DIFF
--- a/core/rchesspgn.js
+++ b/core/rchesspgn.js
@@ -91,6 +91,7 @@ function initializePgnViewer(id, pgnstr){
     'newlineForEachMainMove': true,
     'movesFormat': 'main_on_own_line',
     'autoScrollMoves': true,
+    'hidePGNErrors': true
   }, onViewerInit(id));
 
   if ($('#'+id+'-whitePlayer')[0].innerHTML.length){


### PR DESCRIPTION
I figured I'd make this a separate pull request because you might disagree with me, but I find the alerts when there are pgn errors pretty annoying. I feel they should be silent. Obviously your choice if you want to merge or not